### PR TITLE
Lowercase paramters when converting from camelcase

### DIFF
--- a/htmltidy.js
+++ b/htmltidy.js
@@ -176,7 +176,7 @@ function parseOpts(opts) {
 }
 
 function toHyphens(str) {
-    return str.replace(/([A-Z])/g, function (m, w) { return '-' + w; });
+    return str.replace(/([A-Z])/g, function (m, w) { return '-' + w.toLowerCase(); });
 }
 
 /**


### PR DESCRIPTION
On Darwin at least, improperly cased parameters cause Tidy to fail.
