### PR TITLE
Fixed a bug where the resulting data would be blank.

### DIFF
--- a/htmltidy.js
+++ b/htmltidy.js
@@ -46,7 +46,7 @@ function TidyWorker(opts) {
   this._worker.stderr.on('data', function (data) {
     errors+= data;
   });
-  this._worker.on('exit', function (code) {
+  this._worker.on('close', function (code) {
     switch(code){
       // If there were any warnings or errors from Tiny command
       case TIDY_WARN:


### PR DESCRIPTION
Changed the exit event to be 'close' since 'exit' can be sent even though the stdio streams are still open. The alternative is to use the 'close' event which is emitted when all stdio streams are closed and the program has exited.
