### PR TITLE
Fix issues with multibyte character concating

### DIFF
--- a/htmltidy.js
+++ b/htmltidy.js
@@ -46,7 +46,7 @@ function TidyWorker(opts) {
   this._worker.stderr.on('data', function (data) {
     errors+= data;
   });
-  this._worker.on('exit', function (code) {
+  this._worker.on('close', function (code) {
     switch(code){
       // If there were any warnings or errors from Tiny command
       case TIDY_WARN:
@@ -118,16 +118,16 @@ function tidy(text, opts, cb) {
     throw new Error('no callback provided for tidy');
 
   var worker = new TidyWorker(opts);
-  var result = '';
+  var result = new Array();
   var error = '';
   worker.on('data', function (data) {
-    result+= data;
+    result.push(data);
   });
   worker.on('error', function (data) {
     error+= data;
   });
   worker.on('end', function (code) {
-    cb(error, result);
+    cb(error, Buffer.concat(result).toString());
   });
   worker.end(text);
 }


### PR DESCRIPTION
We can't just use '+' between two Buffer object, it will convert the buffer to string, but when there is a multibyte string, then the string might not be converted correctly.
