### PR TITLE
Fix for sporadic truncation of output files due to incomplete I/O

### DIFF
--- a/htmltidy.js
+++ b/htmltidy.js
@@ -127,7 +127,7 @@ function tidy(text, opts, cb) {
     error+= data;
   });
   worker.on('end', function (code) {
-    cb(error, result);
+    setImmediate(function(){cb(error, result);});
   });
   worker.end(text);
 }


### PR DESCRIPTION
Hi.  I'm using htmltidy as part of a regression test, to compare output of a system with its previous output.  On numerous occasions, one file out of hundreds processed will be truncated somewhere in the middle.  After extensive analysis and experimentation, I determined that the problem seems to be due to Node sometimes firing the subprocess `exit` event shortly _before_ the last `data` event from the subprocess's stdout.  (This is on Windows 7, by the way.)

This one-line change fixes the problem for `tidy()` calls, by delaying the final result callback until Node has finished processing all pending I/O, thus ensuring that the remaining `data` event has a chance to fire before the final callback is invoked.

Without the patch, an average of about 1 (randomly selected) file per two thousand processed is truncated on my computer.  But with the patch, none are ever truncated as far as I can tell.

(The build is a complex one, with lots of other streaming events going on left and right, so I imagine the event ordering is a little less deterministic than in simpler processes using htmltidy, or that are not invoking it hundreds of times in rapid succession.)
