### PR TITLE
Allow htmltidy to use a system tidy if available.

### DIFF
--- a/htmltidy.js
+++ b/htmltidy.js
@@ -3,6 +3,7 @@ var inherits = require('util').inherits;
 var fs = require('fs');
 var path = require('path');
 var spawn = require('child_process').spawn;
+var shell = require('shelljs');
 
 // tidy exit codes
 var TIDY_OK = 0;
@@ -133,7 +134,9 @@ function tidy(text, opts, cb) {
 }
 
 function chooseExec() {
-  var tidyExe;
+  var tidyExe = shell.which('tidy');
+  if (tidyExe !== null) { return tidyExe; }
+  
   switch (process.platform) {
     case 'win32':
       tidyExe = path.join('win32','tidy.exe');
@@ -148,10 +151,11 @@ function chooseExec() {
         throw new Error('unsupported execution platform');
   }
   tidyExe = path.join(__dirname, 'bin', tidyExe);
-
-  var existsSync = fs.existsSync||path.existsSync; // node > 0.6
-  if (!existsSync(tidyExe))
+  
+  var existsSync = fs.existsSync || path.existsSync; // node > 0.6
+  if (!existsSync(tidyExe)) {
       throw new Error('missing tidy executable: ' + tidyExe);
+  }
   return tidyExe;
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "async": "~0.2.1"
   },
   "dependencies": {
-    "shelljs": "~0.3.0",
+    "shelljs": "~0.3.0"
   },
   "optionalDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "devDependencies": {
     "request": "~2.11.4",
+    "shelljs": "~0.3.0",
     "async": "~0.2.1"
   },
   "dependencies": {},

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
   ],
   "devDependencies": {
     "request": "~2.11.4",
-    "shelljs": "~0.3.0",
     "async": "~0.2.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "shelljs": "~0.3.0",
+  },
   "optionalDependencies": {}
 }


### PR DESCRIPTION
While I wasn't excited about adding in a dependency when there were no others it seemed to be the quickest and least intrusive option. It could absolutely be done by an exec call:

```
child_process.exec('command -v tidy', {}, function() { ... });
```

But that would require a bit more tweaking of the existsSync call. If you'd prefer, I can do that instead.

I ended up doing this because the supplied binary of tidy for linux didn't work for me and it took me a good while to figure out that that was the issue. Unsure if it is 32/64 bit or just different linux bundling. I figured the smartest solution was to allow the user ot install a system tidy and have the toolset default to it.
