### PR TITLE
Fixes vavere/htmltidy#24 by expecting for close instead of end

### DIFF
--- a/htmltidy.js
+++ b/htmltidy.js
@@ -126,7 +126,7 @@ function tidy(text, opts, cb) {
   worker.on('error', function (data) {
     error+= data;
   });
-  worker.on('end', function (code) {
+  worker.on('close', function (code) {
     cb(error, result);
   });
   worker.end(text);


### PR DESCRIPTION
While tidying multiple files (using grunt, in my case) I usually ran into the problem that it would output nothing but a command-line counterpart would work as expected.

I eventually figured out that you actually have to expect for a close, not an end, since only close will ensure that everything has being sent to std.out. 

It fixes issue #24 .
